### PR TITLE
Add Playwright automation project and update portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -862,24 +862,33 @@
     <div class="container">
         <h2 data-aos="fade-up">Portfolio Projects</h2>
         <div class="project-grid">
-            <!-- Future project card example -->
+            <!-- AI-powered visual testing project -->
             <div class="project" data-aos="fade-up">
-                <img src="project-future1.jpg" alt="Project 1">
+                <img src="project-ai-visual.jpg" alt="AI Visual Testing">
                 <div class="project-content">
-                    <h3>Future Project Title 1</h3>
-                    <p>A brief description of this upcoming automation framework or testing tool.</p>
-                    <a href="https://dharmindersingh007.github.io/Dharminder.github.io/" target="_blank"><i class="fab fa-github"></i> GitHub</a>
-                    <a href="https://liveprojectlink.com" target="_blank"><i class="fas fa-external-link-alt"></i> Live Demo</a>
+                    <h3>AI-Powered Visual Testing</h3>
+                    <p>Visual regression tests using Selenium and OpenCV to automatically detect UI issues.</p>
+                    <a href="https://github.com/dharmindersingh007/Dharminder.github.io/tree/main/AI-Powered-Visual-Testing" target="_blank"><i class="fab fa-github"></i> GitHub</a>
                 </div>
             </div>
-            <!-- Additional project cards can be added here -->
+
+            <!-- Mobile automation portfolio -->
             <div class="project" data-aos="fade-up">
-                <img src="project-future2.jpg" alt="Project 2">
+                <img src="project-mobile.jpg" alt="Mobile Automation">
                 <div class="project-content">
-                    <h3>Future Project Title 2</h3>
-                    <p>A brief description of an innovative test automation project planned for the near future.</p>
-                    <a href="https://dharmindersingh007.github.io/Dharminder.github.io/" target="_blank"><i class="fab fa-github"></i> GitHub</a>
-                    <a href="https://liveprojectlink.com" target="_blank"><i class="fas fa-external-link-alt"></i> Live Demo</a>
+                    <h3>Mobile Test Automation</h3>
+                    <p>Cross-platform frameworks with Appium, Espresso, and XCUITest for robust mobile testing.</p>
+                    <a href="https://github.com/dharmindersingh007/Dharminder.github.io/tree/main/mobile_test_automation_portfolio" target="_blank"><i class="fab fa-github"></i> GitHub</a>
+                </div>
+            </div>
+
+            <!-- New Playwright project -->
+            <div class="project" data-aos="fade-up">
+                <img src="project-playwright.jpg" alt="Playwright Automation">
+                <div class="project-content">
+                    <h3>Playwright Web Automation</h3>
+                    <p>Modern end-to-end tests in TypeScript leveraging Playwright's reliable cross-browser support.</p>
+                    <a href="https://github.com/dharmindersingh007/Dharminder.github.io/tree/main/playwright-web-automation" target="_blank"><i class="fab fa-github"></i> GitHub</a>
                 </div>
             </div>
         </div>

--- a/playwright-web-automation/README.md
+++ b/playwright-web-automation/README.md
@@ -1,0 +1,16 @@
+# Playwright Web Automation
+
+This project showcases modern web automation using [Playwright](https://playwright.dev/). It includes a simple test written in TypeScript that navigates to the Playwright website, verifies the title, and checks for the installation section.
+
+## Running the tests
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Execute the test suite:
+   ```bash
+   npm test
+   ```
+
+Playwright provides cross-browser testing capabilities with advanced features such as auto-wait, built-in retries, and headless execution.

--- a/playwright-web-automation/package.json
+++ b/playwright-web-automation/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "playwright-web-automation",
+  "version": "1.0.0",
+  "description": "Sample Playwright project demonstrating modern web automation.",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1",
+    "typescript": "^5.4.3"
+  }
+}

--- a/playwright-web-automation/tests/example.spec.ts
+++ b/playwright-web-automation/tests/example.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage has title and links to intro page', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+
+  // Click the get started link.
+  await page.getByRole('link', { name: 'Get started' }).click();
+
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+});

--- a/playwright-web-automation/tsconfig.json
+++ b/playwright-web-automation/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- add Playwright-based automation sample in `playwright-web-automation`
- showcase new project links in portfolio section

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_686b053bb4f08325aae1c9ca173ce0c3